### PR TITLE
Update install-jdk.sh URL for JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
   - source install-jdk.sh --feature 17


### PR DESCRIPTION
Sormuras [removed](https://github.com/sormuras/bach/issues/250#issuecomment-1240653256) master branch. install-jdk.sh from releases/11 branch seems to be working.